### PR TITLE
Upgrade Inertia to Version 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
-                "@inertiajs/inertia": "^0.11.1",
-                "@inertiajs/inertia-vue3": "^0.6.0",
-                "@inertiajs/progress": "^0.2.7",
+                "@inertiajs/vue3": "^1.0.2",
                 "axios": "^1.2.1",
                 "sweetalert": "^2.1.2",
                 "vue": "^3.2.36",
@@ -35,9 +33,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.21.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-            "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+            "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -77,15 +75,39 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
+            "integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
+            "dev": true,
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
-            "integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+            "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.4.0",
+                "espree": "^9.5.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -101,9 +123,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
-            "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+            "version": "8.36.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+            "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -142,46 +164,28 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
-        "node_modules/@inertiajs/inertia": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/@inertiajs/inertia/-/inertia-0.11.1.tgz",
-            "integrity": "sha512-btmV53c54oW4Z9XF0YyTdIUnM7ue0ONy3/KJOz6J1C5CYIwimiKfDMpz8ZbGJuxS+SPdOlNsqj2ZhlHslpJRZg==",
+        "node_modules/@inertiajs/core": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-1.0.2.tgz",
+            "integrity": "sha512-IJryvuNBcOIEZqKaA1vsX++hroovrLfb4jezym/W6NqxpsacoOkCLqWFneiScTaa5IiU0Wv0Li3lCuxK7DwTEQ==",
             "dependencies": {
-                "axios": "^0.21.1",
+                "axios": "^1.2.0",
                 "deepmerge": "^4.0.0",
+                "nprogress": "^0.2.0",
                 "qs": "^6.9.0"
             }
         },
-        "node_modules/@inertiajs/inertia-vue3": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/inertia-vue3/-/inertia-vue3-0.6.0.tgz",
-            "integrity": "sha512-qhPBtd/G0VS7vVVbYw1rrqKB6JqRusxqt+5ec2GLmK6t7fTlBBnZ3KsakmGZLSM1m1OGkNcfn4ifmCk3zfA8RQ==",
+        "node_modules/@inertiajs/vue3": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-1.0.2.tgz",
+            "integrity": "sha512-8LU6fd3BcmmxN7kHWgF06zKXnqZibi3+2UJ5Im1WsMXfqZO4jwaz5qFU2NjOBQEgcm5t+FNv1fbAESGEC8eezg==",
             "dependencies": {
+                "@inertiajs/core": "1.0.2",
                 "lodash.clonedeep": "^4.5.0",
                 "lodash.isequal": "^4.5.0"
             },
             "peerDependencies": {
-                "@inertiajs/inertia": "^0.11.0",
                 "vue": "^3.0.0"
-            }
-        },
-        "node_modules/@inertiajs/inertia/node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dependencies": {
-                "follow-redirects": "^1.14.0"
-            }
-        },
-        "node_modules/@inertiajs/progress": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@inertiajs/progress/-/progress-0.2.7.tgz",
-            "integrity": "sha512-zxadfLlBPIUvTE9g5k71V/Ayzo8P9kEp4hV4UKywCC2kURufxV7bycbZqU1GeMCFGDT+VRrjXNl676Pwwa1HoQ==",
-            "dependencies": {
-                "nprogress": "^0.2.0"
-            },
-            "peerDependencies": {
-                "@inertiajs/inertia": "^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -220,9 +224,9 @@
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+            "version": "2.11.7",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+            "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -299,19 +303,19 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.53.0.tgz",
-            "integrity": "sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz",
+            "integrity": "sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.53.0",
-                "@typescript-eslint/type-utils": "5.53.0",
-                "@typescript-eslint/utils": "5.53.0",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/type-utils": "5.56.0",
+                "@typescript-eslint/utils": "5.56.0",
                 "debug": "^4.3.4",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             },
@@ -333,14 +337,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
-            "integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
+            "integrity": "sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.53.0",
-                "@typescript-eslint/types": "5.53.0",
-                "@typescript-eslint/typescript-estree": "5.53.0",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -360,13 +364,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
-            "integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
+            "integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.53.0",
-                "@typescript-eslint/visitor-keys": "5.53.0"
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/visitor-keys": "5.56.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -377,13 +381,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
-            "integrity": "sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
+            "integrity": "sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.53.0",
-                "@typescript-eslint/utils": "5.53.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
+                "@typescript-eslint/utils": "5.56.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -404,9 +408,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
-            "integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
+            "integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -417,13 +421,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
-            "integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
+            "integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.53.0",
-                "@typescript-eslint/visitor-keys": "5.53.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/visitor-keys": "5.56.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -444,18 +448,18 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.53.0.tgz",
-            "integrity": "sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
+            "integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
             "dev": true,
             "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.53.0",
-                "@typescript-eslint/types": "5.53.0",
-                "@typescript-eslint/typescript-estree": "5.53.0",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
                 "semver": "^7.3.7"
             },
             "engines": {
@@ -470,12 +474,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
-            "integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
+            "integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.53.0",
+                "@typescript-eslint/types": "5.56.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -914,9 +918,9 @@
             "dev": true
         },
         "node_modules/deepmerge": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-            "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1334,13 +1338,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
-            "integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
+            "version": "8.36.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+            "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^2.0.0",
-                "@eslint/js": "8.35.0",
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@eslint/eslintrc": "^2.0.1",
+                "@eslint/js": "8.36.0",
                 "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -1351,9 +1357,8 @@
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
                 "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.4.0",
+                "espree": "^9.5.0",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -1375,7 +1380,6 @@
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
                 "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
@@ -1391,9 +1395,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-            "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+            "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
@@ -1403,12 +1407,12 @@
             }
         },
         "node_modules/eslint-plugin-vue": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.9.0.tgz",
-            "integrity": "sha512-YbubS7eK0J7DCf0U2LxvVP7LMfs6rC6UltihIgval3azO3gyDwEGVgsCMe1TmDiEkl6GdMKfRpaME6QxIYtzDQ==",
+            "version": "9.10.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.10.0.tgz",
+            "integrity": "sha512-2MgP31OBf8YilUvtakdVMc8xVbcMp7z7/iQj8LHVpXrSXHPXSJRUIGSPFI6b6pyCx/buKaFJ45ycqfHvQRiW2g==",
             "dev": true,
             "dependencies": {
-                "eslint-utils": "^3.0.0",
+                "@eslint-community/eslint-utils": "^4.3.0",
                 "natural-compare": "^1.4.0",
                 "nth-check": "^2.0.1",
                 "postcss-selector-parser": "^6.0.9",
@@ -1434,33 +1438,6 @@
             },
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "dependencies": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "engines": {
-                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=5"
-            }
-        },
-        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/eslint-visitor-keys": {
@@ -1495,9 +1472,9 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+            "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.8.0",
@@ -1512,9 +1489,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-            "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
             "dev": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -1918,9 +1895,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
-            "integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+            "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
             "dev": true
         },
         "node_modules/import-fresh": {
@@ -2046,9 +2023,9 @@
             "dev": true
         },
         "node_modules/js-sdsl": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-            "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+            "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -2224,9 +2201,15 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -2480,9 +2463,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-            "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -2514,9 +2497,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+            "version": "6.11.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+            "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
             "dependencies": {
                 "side-channel": "^1.0.4"
             },
@@ -2557,18 +2540,6 @@
             },
             "engines": {
                 "node": ">=8.10.0"
-            }
-        },
-        "node_modules/regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
             }
         },
         "node_modules/resolve": {
@@ -2661,9 +2632,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.58.3",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.58.3.tgz",
-            "integrity": "sha512-Q7RaEtYf6BflYrQ+buPudKR26/lH+10EmO9bBqbmPh/KeLqv8bjpTNqxe71ocONqXq+jYiCbpPUmQMS+JJPk4A==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
+            "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -3118,9 +3089,9 @@
     },
     "dependencies": {
         "@babel/parser": {
-            "version": "7.21.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-            "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ=="
+            "version": "7.21.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+            "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ=="
         },
         "@esbuild/android-arm": {
             "version": "0.15.18",
@@ -3136,15 +3107,30 @@
             "dev": true,
             "optional": true
         },
+        "@eslint-community/eslint-utils": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^3.3.0"
+            }
+        },
+        "@eslint-community/regexpp": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
+            "integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
+            "dev": true
+        },
         "@eslint/eslintrc": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
-            "integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+            "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.4.0",
+                "espree": "^9.5.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -3154,9 +3140,9 @@
             }
         },
         "@eslint/js": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
-            "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+            "version": "8.36.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+            "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
             "dev": true
         },
         "@humanwhocodes/config-array": {
@@ -3182,41 +3168,25 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
-        "@inertiajs/inertia": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/@inertiajs/inertia/-/inertia-0.11.1.tgz",
-            "integrity": "sha512-btmV53c54oW4Z9XF0YyTdIUnM7ue0ONy3/KJOz6J1C5CYIwimiKfDMpz8ZbGJuxS+SPdOlNsqj2ZhlHslpJRZg==",
+        "@inertiajs/core": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-1.0.2.tgz",
+            "integrity": "sha512-IJryvuNBcOIEZqKaA1vsX++hroovrLfb4jezym/W6NqxpsacoOkCLqWFneiScTaa5IiU0Wv0Li3lCuxK7DwTEQ==",
             "requires": {
-                "axios": "^0.21.1",
+                "axios": "^1.2.0",
                 "deepmerge": "^4.0.0",
+                "nprogress": "^0.2.0",
                 "qs": "^6.9.0"
-            },
-            "dependencies": {
-                "axios": {
-                    "version": "0.21.4",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-                    "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-                    "requires": {
-                        "follow-redirects": "^1.14.0"
-                    }
-                }
             }
         },
-        "@inertiajs/inertia-vue3": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/inertia-vue3/-/inertia-vue3-0.6.0.tgz",
-            "integrity": "sha512-qhPBtd/G0VS7vVVbYw1rrqKB6JqRusxqt+5ec2GLmK6t7fTlBBnZ3KsakmGZLSM1m1OGkNcfn4ifmCk3zfA8RQ==",
+        "@inertiajs/vue3": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-1.0.2.tgz",
+            "integrity": "sha512-8LU6fd3BcmmxN7kHWgF06zKXnqZibi3+2UJ5Im1WsMXfqZO4jwaz5qFU2NjOBQEgcm5t+FNv1fbAESGEC8eezg==",
             "requires": {
+                "@inertiajs/core": "1.0.2",
                 "lodash.clonedeep": "^4.5.0",
                 "lodash.isequal": "^4.5.0"
-            }
-        },
-        "@inertiajs/progress": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@inertiajs/progress/-/progress-0.2.7.tgz",
-            "integrity": "sha512-zxadfLlBPIUvTE9g5k71V/Ayzo8P9kEp4hV4UKywCC2kURufxV7bycbZqU1GeMCFGDT+VRrjXNl676Pwwa1HoQ==",
-            "requires": {
-                "nprogress": "^0.2.0"
             }
         },
         "@nodelib/fs.scandir": {
@@ -3246,9 +3216,9 @@
             }
         },
         "@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+            "version": "2.11.7",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+            "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
             "dev": true
         },
         "@types/bootstrap": {
@@ -3321,71 +3291,71 @@
             }
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.53.0.tgz",
-            "integrity": "sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz",
+            "integrity": "sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.53.0",
-                "@typescript-eslint/type-utils": "5.53.0",
-                "@typescript-eslint/utils": "5.53.0",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/type-utils": "5.56.0",
+                "@typescript-eslint/utils": "5.56.0",
                 "debug": "^4.3.4",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "natural-compare-lite": "^1.4.0",
-                "regexpp": "^3.2.0",
                 "semver": "^7.3.7",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
-            "integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
+            "integrity": "sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.53.0",
-                "@typescript-eslint/types": "5.53.0",
-                "@typescript-eslint/typescript-estree": "5.53.0",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
-            "integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
+            "integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.53.0",
-                "@typescript-eslint/visitor-keys": "5.53.0"
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/visitor-keys": "5.56.0"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
-            "integrity": "sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
+            "integrity": "sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "5.53.0",
-                "@typescript-eslint/utils": "5.53.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
+                "@typescript-eslint/utils": "5.56.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
-            "integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
+            "integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
-            "integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
+            "integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.53.0",
-                "@typescript-eslint/visitor-keys": "5.53.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/visitor-keys": "5.56.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -3394,28 +3364,28 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.53.0.tgz",
-            "integrity": "sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
+            "integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
             "dev": true,
             "requires": {
+                "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.53.0",
-                "@typescript-eslint/types": "5.53.0",
-                "@typescript-eslint/typescript-estree": "5.53.0",
+                "@typescript-eslint/scope-manager": "5.56.0",
+                "@typescript-eslint/types": "5.56.0",
+                "@typescript-eslint/typescript-estree": "5.56.0",
                 "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0",
                 "semver": "^7.3.7"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
-            "integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
+            "version": "5.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
+            "integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.53.0",
+                "@typescript-eslint/types": "5.56.0",
                 "eslint-visitor-keys": "^3.3.0"
             }
         },
@@ -3758,9 +3728,9 @@
             "dev": true
         },
         "deepmerge": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-            "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
         },
         "defu": {
             "version": "6.1.2",
@@ -3973,13 +3943,15 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
-            "integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
+            "version": "8.36.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+            "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^2.0.0",
-                "@eslint/js": "8.35.0",
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.4.0",
+                "@eslint/eslintrc": "^2.0.1",
+                "@eslint/js": "8.36.0",
                 "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -3990,9 +3962,8 @@
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
                 "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.4.0",
+                "espree": "^9.5.0",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -4014,7 +3985,6 @@
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
                 "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
@@ -4039,19 +4009,19 @@
             }
         },
         "eslint-config-prettier": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-            "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+            "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
             "dev": true,
             "requires": {}
         },
         "eslint-plugin-vue": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.9.0.tgz",
-            "integrity": "sha512-YbubS7eK0J7DCf0U2LxvVP7LMfs6rC6UltihIgval3azO3gyDwEGVgsCMe1TmDiEkl6GdMKfRpaME6QxIYtzDQ==",
+            "version": "9.10.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.10.0.tgz",
+            "integrity": "sha512-2MgP31OBf8YilUvtakdVMc8xVbcMp7z7/iQj8LHVpXrSXHPXSJRUIGSPFI6b6pyCx/buKaFJ45ycqfHvQRiW2g==",
             "dev": true,
             "requires": {
-                "eslint-utils": "^3.0.0",
+                "@eslint-community/eslint-utils": "^4.3.0",
                 "natural-compare": "^1.4.0",
                 "nth-check": "^2.0.1",
                 "postcss-selector-parser": "^6.0.9",
@@ -4070,23 +4040,6 @@
                 "estraverse": "^4.1.1"
             }
         },
-        "eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "requires": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-                    "dev": true
-                }
-            }
-        },
         "eslint-visitor-keys": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
@@ -4094,9 +4047,9 @@
             "dev": true
         },
         "espree": {
-            "version": "9.4.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+            "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
             "dev": true,
             "requires": {
                 "acorn": "^8.8.0",
@@ -4105,9 +4058,9 @@
             }
         },
         "esquery": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-            "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
             "dev": true,
             "requires": {
                 "estraverse": "^5.1.0"
@@ -4400,9 +4353,9 @@
             "dev": true
         },
         "immutable": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
-            "integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+            "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
             "dev": true
         },
         "import-fresh": {
@@ -4495,9 +4448,9 @@
             "dev": true
         },
         "js-sdsl": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-            "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+            "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
             "dev": true
         },
         "js-yaml": {
@@ -4636,9 +4589,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -4813,9 +4766,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-            "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
             "dev": true
         },
         "promise-polyfill": {
@@ -4835,9 +4788,9 @@
             "dev": true
         },
         "qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+            "version": "6.11.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+            "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
             "requires": {
                 "side-channel": "^1.0.4"
             }
@@ -4856,12 +4809,6 @@
             "requires": {
                 "picomatch": "^2.2.1"
             }
-        },
-        "regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true
         },
         "resolve": {
             "version": "1.22.1",
@@ -4914,9 +4861,9 @@
             }
         },
         "sass": {
-            "version": "1.58.3",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.58.3.tgz",
-            "integrity": "sha512-Q7RaEtYf6BflYrQ+buPudKR26/lH+10EmO9bBqbmPh/KeLqv8bjpTNqxe71ocONqXq+jYiCbpPUmQMS+JJPk4A==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
+            "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
         "vue-eslint-parser": "^9.1.0"
     },
     "dependencies": {
-        "@inertiajs/inertia": "^0.11.1",
-        "@inertiajs/inertia-vue3": "^0.6.0",
-        "@inertiajs/progress": "^0.2.7",
+        "@inertiajs/vue3": "^1.0.2",
         "axios": "^1.2.1",
         "sweetalert": "^2.1.2",
         "vue": "^3.2.36",

--- a/resources/scripts/main.ts
+++ b/resources/scripts/main.ts
@@ -1,11 +1,10 @@
 import "@/scss/stisla.scss";
 
-import { createApp, h } from 'vue'
-import { createInertiaApp } from '@inertiajs/inertia-vue3'
-import { resolvePageComponent } from 'vite-plugin-laravel/inertia'
 import { Ziggy } from "@/scripts/utils/ziggy";
 import ZiggyVue from "@/scripts/utils/ziggy/ZiggyVue";
-import { InertiaProgress } from "@inertiajs/progress";
+import { createInertiaApp } from "@inertiajs/vue3";
+import { resolvePageComponent } from "vite-plugin-laravel/inertia";
+import { createApp, h } from "vue";
 import { Config } from "ziggy-js";
 
 const appName = window.document.getElementsByTagName('title')[0]?.innerText || 'Laravel';
@@ -13,12 +12,10 @@ const appName = window.document.getElementsByTagName('title')[0]?.innerText || '
 createInertiaApp({
   title: (title) => title ? `${title} - ${appName}` : appName,
   resolve: (name) => resolvePageComponent(name, import.meta.glob('../views/pages/**/*.vue')),
-  setup({ el, app, props, plugin }) {
-    createApp({ render: () => h(app, props) })
+  setup({ el, App, props, plugin }) {
+    createApp({ render: () => h(App, props) })
       .use(plugin)
       .use(ZiggyVue, Ziggy as Config)
       .mount(el)
   },
 })
-
-InertiaProgress.init();

--- a/resources/scripts/types/page-props.ts
+++ b/resources/scripts/types/page-props.ts
@@ -1,4 +1,4 @@
-declare module "@inertiajs/inertia" {
+declare module "@inertiajs/core" {
   interface PageProps {
     flash: FlashMessage,
     auth?: AuthProps,

--- a/resources/scripts/utils/ziggy/useRoute.ts
+++ b/resources/scripts/utils/ziggy/useRoute.ts
@@ -1,4 +1,4 @@
-import { usePage } from '@inertiajs/inertia-vue3';
+import { usePage } from '@inertiajs/vue3';
 import { computed, inject } from 'vue';
 import { RouteParamsWithQueryOverload } from 'ziggy-js';
 import { RouteName, ZiggyRoute } from './type';
@@ -11,7 +11,7 @@ export function useRoute() {
     (name: RouteName): boolean;
     (name: RouteName, params: RouteParamsWithQueryOverload): boolean;
   }>(() => {
-    usePage().url.value;
+    usePage().url;
 
     return (name: string, params?: RouteParamsWithQueryOverload) => route().current(name, params);
   });

--- a/resources/views/components/admin/layout/NavBar/UserMenu.vue
+++ b/resources/views/components/admin/layout/NavBar/UserMenu.vue
@@ -29,7 +29,7 @@
 
 <script setup lang="ts">
 import { useRoute } from "@/scripts/utils/ziggy/useRoute";
-import { useForm, usePage } from "@inertiajs/inertia-vue3";
+import { useForm, usePage } from "@inertiajs/vue3";
 import { computed } from "vue";
 
 const { route } = useRoute();
@@ -38,7 +38,7 @@ const logout = () => {
   useForm({}).delete(route("admin.logout"));
 };
 
-const user = computed(() => usePage().props.value.auth?.user);
+const user = computed(() => usePage().props.auth?.user);
 const avatar = computed(() => {
   const params = new URLSearchParams({
     name: user.value?.name || "User",

--- a/resources/views/components/admin/layout/Page/PageSection.vue
+++ b/resources/views/components/admin/layout/Page/PageSection.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-import { Link } from "@inertiajs/inertia-vue3";
+import { Link } from "@inertiajs/vue3";
 import { inject, watch } from "vue";
 
 const props = withDefaults(

--- a/resources/views/components/admin/layout/SideBar/SideBar.vue
+++ b/resources/views/components/admin/layout/SideBar/SideBar.vue
@@ -79,7 +79,7 @@ import initStisla from "@/scripts/utils/stisla";
 import SideBarLink from "./SideBarLink.vue";
 import SideBarHeader from "./SideBarHeader.vue";
 import SideBarDropdown from "./SideBarDropdown.vue";
-import { Link } from "@inertiajs/inertia-vue3";
+import { Link } from "@inertiajs/vue3";
 import { useRoute } from "@/scripts/utils/ziggy/useRoute";
 
 const { routeIs } = useRoute();

--- a/resources/views/components/admin/layout/SideBar/SideBarLink.vue
+++ b/resources/views/components/admin/layout/SideBar/SideBarLink.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script setup lang="ts">
-import { Link } from "@inertiajs/inertia-vue3";
+import { Link } from "@inertiajs/vue3";
 
 defineProps<{
   href: string,

--- a/resources/views/components/admin/ui/Button/LinkButton.vue
+++ b/resources/views/components/admin/ui/Button/LinkButton.vue
@@ -12,7 +12,7 @@ import type {
 } from "@/scripts/types/ui";
 import { useBaseButton } from "@/scripts/composables/ui/button/useBaseButton";
 import { computed } from "vue";
-import { Link } from "@inertiajs/inertia-vue3";
+import { Link } from "@inertiajs/vue3";
 
 const { getClassVariant, getClassSize, getClassShape } = useBaseButton();
 

--- a/resources/views/components/admin/ui/Pagination/BasePagination.vue
+++ b/resources/views/components/admin/ui/Pagination/BasePagination.vue
@@ -18,7 +18,7 @@
 
 <script setup lang="ts">
 import { PaginationLink } from "@/scripts/types/ui";
-import { Link } from "@inertiajs/inertia-vue3";
+import { Link } from "@inertiajs/vue3";
 
 withDefaults(defineProps<{
   links: PaginationLink[];

--- a/resources/views/pages/admin/auth/login-2.vue
+++ b/resources/views/pages/admin/auth/login-2.vue
@@ -112,7 +112,7 @@
 
 <script setup lang="ts">
 import { useRoute } from '@/scripts/utils/ziggy/useRoute';
-import { Head, useForm } from '@inertiajs/inertia-vue3';
+import { Head, useForm } from '@inertiajs/vue3';
 
 const { route } = useRoute();
 const loginForm = useForm({

--- a/resources/views/pages/admin/auth/login.vue
+++ b/resources/views/pages/admin/auth/login.vue
@@ -100,7 +100,7 @@
 
 <script setup lang="ts">
 import { useRoute } from '@/scripts/utils/ziggy/useRoute';
-import { Head, useForm } from '@inertiajs/inertia-vue3';
+import { Head, useForm } from '@inertiajs/vue3';
 
 const { route } = useRoute();
 const loginForm = useForm({

--- a/resources/views/pages/admin/component/input/index.vue
+++ b/resources/views/pages/admin/component/input/index.vue
@@ -28,7 +28,7 @@ import PageSection from "@components/admin/layout/Page/PageSection.vue";
 import PageTitle from "@components/admin/layout/Page/PageTitle.vue";
 import InputBase from "@components/admin/ui/Input/InputBase.vue";
 
-import { Head } from "@inertiajs/inertia-vue3";
+import { Head } from "@inertiajs/vue3";
 import { ref } from "vue";
 
 const name = ref("");

--- a/resources/views/pages/admin/component/modal/index.vue
+++ b/resources/views/pages/admin/component/modal/index.vue
@@ -155,7 +155,7 @@ import PageDescription from "@components/admin/layout/Page/PageDescription.vue";
 import PageSection from "@components/admin/layout/Page/PageSection.vue";
 import PageTitle from "@components/admin/layout/Page/PageTitle.vue";
 import BaseModal from "@components/admin/ui/Modal/BaseModal.vue";
-import { Head } from "@inertiajs/inertia-vue3";
+import { Head } from "@inertiajs/vue3";
 
 function submit() {
   console.log("submitted");

--- a/resources/views/pages/admin/component/pagination/index.vue
+++ b/resources/views/pages/admin/component/pagination/index.vue
@@ -36,7 +36,7 @@ import PageDescription from "@/views/components/admin/layout/Page/PageDescriptio
 import PageSection from "@/views/components/admin/layout/Page/PageSection.vue";
 import PageTitle from "@/views/components/admin/layout/Page/PageTitle.vue";
 import BasePagination from "@/views/components/admin/ui/Pagination/BasePagination.vue";
-import { Head } from "@inertiajs/inertia-vue3";
+import { Head } from "@inertiajs/vue3";
 
 type Users = {
   links: PaginationLink[];

--- a/resources/views/pages/admin/component/select2/index.vue
+++ b/resources/views/pages/admin/component/select2/index.vue
@@ -50,7 +50,7 @@ import PageDescription from "@components/admin/layout/Page/PageDescription.vue";
 import PageSection from "@components/admin/layout/Page/PageSection.vue";
 import PageTitle from "@components/admin/layout/Page/PageTitle.vue";
 import Select2 from "@components/admin/ui/Select/Select2.vue";
-import { Head } from "@inertiajs/inertia-vue3";
+import { Head } from "@inertiajs/vue3";
 import { ref, watch } from 'vue';
 
 const selectDefault = ref(2);

--- a/resources/views/pages/admin/component/sweet-alert/index.vue
+++ b/resources/views/pages/admin/component/sweet-alert/index.vue
@@ -38,7 +38,7 @@ import PageDescription from "@/views/components/admin/layout/Page/PageDescriptio
 import PageSection from "@/views/components/admin/layout/Page/PageSection.vue";
 import PageTitle from "@/views/components/admin/layout/Page/PageTitle.vue";
 import BaseButton from "@/views/components/admin/ui/Button/BaseButton.vue";
-import { Head } from "@inertiajs/inertia-vue3";
+import { Head } from "@inertiajs/vue3";
 
 const {
   successAlert,

--- a/resources/views/pages/admin/dashboard/index.vue
+++ b/resources/views/pages/admin/dashboard/index.vue
@@ -11,7 +11,7 @@
 import PageDescription from "@components/admin/layout/Page/PageDescription.vue";
 import PageSection from "@components/admin/layout/Page/PageSection.vue";
 import PageTitle from "@components/admin/layout/Page/PageTitle.vue";
-import { Head } from "@inertiajs/inertia-vue3";
+import { Head } from "@inertiajs/vue3";
 </script>
 
 <style scoped></style>

--- a/resources/views/pages/admin/error.vue
+++ b/resources/views/pages/admin/error.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { Head } from "@inertiajs/inertia-vue3";
+import { Head } from "@inertiajs/vue3";
 import { computed } from "vue";
 
 const props = defineProps<{


### PR DESCRIPTION
I am upgrading inertia to version 1 using [this guide](https://inertiajs.com/upgrade-guide). 

Here are the main points of the changes:

1. Rename package dependencies to `@inertiajs/vue3`.
2. Change the custom `PageProps` module to `@inertiajs/core`.
3. Fix `usePage`.